### PR TITLE
fix path to examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,33 +8,33 @@
     <h1>Angular Examples</h1>
     <p>Dart code examples for <a href="https://webdev.dartlang.org/angular">webdev.dartlang.org/angular</a>:</p>
     <ul>
-      <li><a href="https://webdev.dartlang.org/examples/ng/doc/quickstart">QuickStart</a></li>
+      <li><a href="https://webdev.dartlang.org/examples/quickstart">QuickStart</a></li>
       <li> Tutorial
         <ul>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/toh-1">Part 1</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/toh-2">Part 2</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/toh-3">Part 3</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/toh-4">Part 4</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/toh-5">Part 5</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/toh-6">Part 6</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/toh-1">Part 1</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/toh-2">Part 2</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/toh-3">Part 3</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/toh-4">Part 4</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/toh-5">Part 5</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/toh-6">Part 6</a></li>
         </ul>
       </li>
       <li> Basics and Developer Guide (alphabetical order)
         <ul>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/architecture">Architecture</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/attribute-directives">Attribute Directives</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/component-styles">Component Styles</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/dependency-injection">Dependency Injection</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/displaying-data">Displaying Data</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/forms">Forms</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/hierarchical-dependency-injection">Hierarchical Dependency Injection</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/lifecycle-hooks">Lifecycle Hooks</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/pipes">Pipes</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/router">Router</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/security">Security</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/server-communication">HTTP Client</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/template-syntax">Template Syntax</a></li>
-          <li><a href="https://webdev.dartlang.org/examples/ng/doc/user-input">User Input</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/architecture">Architecture</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/attribute-directives">Attribute Directives</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/component-styles">Component Styles</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/dependency-injection">Dependency Injection</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/displaying-data">Displaying Data</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/forms">Forms</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/hierarchical-dependency-injection">Hierarchical Dependency Injection</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/lifecycle-hooks">Lifecycle Hooks</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/pipes">Pipes</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/router">Router</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/security">Security</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/server-communication">HTTP Client</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/template-syntax">Template Syntax</a></li>
+          <li><a href="https://webdev.dartlang.org/examples/user-input">User Input</a></li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
The paths to the examples changed a little while ago (the `/ng/doc` part of the path was dropped). Contributes to https://github.com/dart-lang/site-webdev/issues/774.